### PR TITLE
fix uwebsocket import and websocket handshake

### DIFF
--- a/uasyncio.websocket.server/uasyncio/websocket/server.py
+++ b/uasyncio.websocket.server/uasyncio/websocket/server.py
@@ -7,8 +7,7 @@ def make_respkey(webkey):
     d = uhashlib.sha1(webkey)
     d.update(b"258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
     respkey = d.digest()
-    respkey = ubinascii.b2a_base64(respkey) #[:-1]
-    # Return with trailing "\n".
+    respkey = ubinascii.b2a_base64(respkey)[:-1]
     return respkey
 
 
@@ -50,10 +49,7 @@ Upgrade: websocket\r
 Connection: Upgrade\r
 Sec-WebSocket-Accept: """)
         await writer.awrite(respkey)
-        # This will lead to "<key>\n\r\n" being written. Not exactly
-        # "\r\n\r\n", but browsers seem to eat it.
-        await writer.awrite("\r\n")
-        #await writer.awrite("\r\n\r\n")
+        await writer.awrite("\r\n\r\n")
 
         print("Finished webrepl handshake")
 

--- a/uasyncio.websocket.server/uasyncio/websocket/server.py
+++ b/uasyncio.websocket.server/uasyncio/websocket/server.py
@@ -1,6 +1,6 @@
 import uasyncio
 import uhashlib, ubinascii
-import websocket
+import uwebsocket as websocket
 
 
 def make_respkey(webkey):


### PR DESCRIPTION
- Fixed builtin uwebsocket module import.
- Fixed server handshake. Add extra '\r\n' after last header line to indicate end of the header. Without it websocket server doesn't work properly with safari browser on mac.