### PR TITLE
random: fix randrange to accept 1 as parameter

### DIFF
--- a/random/random.py
+++ b/random/random.py
@@ -6,8 +6,8 @@ def randrange(start, stop=None):
         stop = start
         start = 0
     upper = stop - start
-    bits = 0
-    pwr2 = 1
+    bits = 1
+    pwr2 = 2
     while upper > pwr2:
         pwr2 <<= 1
         bits += 1


### PR DESCRIPTION
makes randrange(1) return 0 instead of raising a ValueError.
This indirectly fix the following with correct behavior:
- shuffle of a 1-lenght sequence -> don't change the sequence
- choice of a 1-lenght sequence -> return the only element