### PR TITLE
uasyncio.websocket.server: Allow the sending of binary WebSocket frames

### DIFF
--- a/uasyncio.websocket.server/uasyncio/websocket/server.py
+++ b/uasyncio.websocket.server/uasyncio/websocket/server.py
@@ -17,9 +17,9 @@ class WSWriter:
         # Reader is passed for symmetry with WSReader() and ignored.
         self.s = writer
 
-    async def awrite(self, data):
+    async def awrite(self, data, binary=False):
         assert len(data) < 126
-        await self.s.awrite(b"\x81")
+        await self.s.awrite(b"\x82" if binary else b"\x81")
         await self.s.awrite(bytes([len(data)]))
         await self.s.awrite(data)
 


### PR DESCRIPTION
Hello, I needed to send WebSocket binary frames and I had to change the hardcoded packet header to do so.
I'm not sure if you are interested in this commit. If so, fell free to merge.