### PR TITLE
os.path: adds realpath() method

### DIFF
--- a/os.path/metadata.txt
+++ b/os.path/metadata.txt
@@ -2,3 +2,4 @@ srctype = pycopy-lib
 type = package
 version = 0.2.2
 author = Paul Sokolovsky
+depends = ffilib

--- a/os.path/os/path.py
+++ b/os.path/os/path.py
@@ -1,4 +1,5 @@
 import os
+import ffilib
 
 
 sep = "/"
@@ -79,6 +80,13 @@ def islink(path):
     except OSError:
         return False
 
+def realpath(path):
+    libc = ffilib.libc()
+    if isinstance(path, str) or isinstance(path, bytes):
+        realpath_ = libc.func("s", "realpath", "ss")
+        #NOTE: memory leak! should free() returned pointer, see man realpath
+        return realpath_(path, None)
+    raise TypeError
 
 def expanduser(s):
     if s == "~" or s.startswith("~/"):


### PR DESCRIPTION
os.path: adds realpath() method
os.path: depends on ffilib

os.path imports os which relies on ffilib, so it looks to me as if ffilib should be added to dependencies either way.
If there's no ffilib available, import of os.path will fail. 